### PR TITLE
Add OpenAI Codex landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Benefícios do Codex da OpenAI</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+        header { background-color: #4CAF50; color: white; padding: 1rem; text-align: center; }
+        main { margin: 2rem; }
+        h1 { color: #333; }
+        ul { list-style-type: disc; margin-left: 2rem; }
+        footer { background-color: #f1f1f1; text-align: center; padding: 1rem; margin-top: 2rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Benefícios de usar o Codex da OpenAI</h1>
+    </header>
+    <main>
+        <p>O Codex da OpenAI é uma plataforma poderosa que permite integrar a inteligência artificial diretamente em aplicações e fluxos de trabalho. Aqui estão alguns dos principais benefícios:</p>
+        <ul>
+            <li><strong>Aumento de produtividade:</strong> automatiza tarefas repetitivas e agiliza o desenvolvimento de código.</li>
+            <li><strong>Simplifica processos:</strong> permite gerar soluções e exemplos de código rapidamente.</li>
+            <li><strong>Facilidade de integração:</strong> se conecta facilmente a diferentes linguagens e ferramentas.</li>
+            <li><strong>Suporte a aprendizadov:</strong> ajuda a aprender novas linguagens e APIs com exemplos práticos.</li>
+            <li><strong>Atualização constante:</strong> o modelo evolui com o tempo, oferecendo respostas cada vez mais precisas.</li>
+        </ul>
+    </main>
+    <footer>
+        <p>Saiba mais em <a href="https://openai.com" target="_blank">openai.com</a></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` to showcase the benefits of OpenAI Codex

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc1ba842c832b8b50b0e4c182cc84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Portuguese-language webpage highlighting the benefits of OpenAI's Codex, featuring a styled header, main content with a descriptive list, and a footer linking to OpenAI's website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->